### PR TITLE
feat: added redrive and DLQ support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "biomejs.biome"
+  ]
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "space"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "clean": "rimraf dist/*",
     "prebuild": "npm run clean",
     "lint": "biome lint",
-    "test": "tsx --test --experimental-test-coverage ./src/**.test.ts"
+    "test": "tsx --test --experimental-test-coverage ./src/**.test.ts",
+    "test:dist": "node --test --experimental-test-coverage ./dist/**.test.js",
+    "pretest:dist": "npm run build"
   },
   "main": "dist/index.js",
   "repository": "https://github.com/pete-otaqui/q-ball",


### PR DESCRIPTION
QBall can redrive messages up to a configurable number of attempts.

QBall can send messages to a secondary DLQ instance of QBall where they
throw errors beyond the redrive attempt limit.

- Added biome.json for formal settings
- Added test runner of the built code (because node's own coverage
  doesn't give reliable line numbers when run via `tsx`)

Closes #4
