### PR TITLE
chore(ci/cd): added `--allow-unrelated-histories`

### DIFF
--- a/.github/workflows/main-pr-close.yml
+++ b/.github/workflows/main-pr-close.yml
@@ -38,7 +38,7 @@ jobs:
           git fetch origin dev
           git checkout -B dev origin/dev
           echo "Previous DEV commit: $(git rev-parse --short HEAD)"
-          git merge main --ff-only
+          git merge main --ff-only --allow-unrelated-histories
           echo "Current DEV commit: $(git rev-parse --short HEAD)"
           git push origin dev --force
       - id: set-version


### PR DESCRIPTION
Should allow "git in ci action" to perform the FF merge
